### PR TITLE
Add define, weather and remind modules

### DIFF
--- a/commands/define.py
+++ b/commands/define.py
@@ -1,0 +1,22 @@
+class Command:
+    trigger = ["define"]
+
+    def __init__(self, context):
+        self.context = context
+        self.settings = context.get("settings", {})
+
+    async def run(self, args: str) -> str:
+        word = args.strip()
+        if not word:
+            return "[Lex] Define what exactly?"
+        if not self.settings.get("use_cloud"):
+            return f"[Lex] Can't look up '{word}' without cloud access."
+        import asyncio, requests
+        url = f"https://api.dictionaryapi.dev/api/v2/entries/en/{word}"
+        try:
+            resp = await asyncio.to_thread(requests.get, url, timeout=5)
+            data = resp.json()
+            meaning = data[0]["meanings"][0]["definitions"][0]["definition"]
+            return f"{word}: {meaning}"
+        except Exception as e:
+            return f"[Lex] Couldn't fetch definition: {e}"

--- a/commands/remind.py
+++ b/commands/remind.py
@@ -1,0 +1,41 @@
+import asyncio
+import json
+import os
+
+
+class Command:
+    trigger = ["remind"]
+
+    def __init__(self, context):
+        self.context = context
+        self.file = os.path.join("memory", "reminders.json")
+
+    def _read_json(self):
+        if not os.path.exists(self.file):
+            return []
+        with open(self.file, "r", encoding="utf-8") as fh:
+            try:
+                return json.load(fh)
+            except Exception:
+                return []
+
+    def _write_json(self, data):
+        with open(self.file, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    async def _load(self):
+        return await asyncio.to_thread(self._read_json)
+
+    async def _save(self, data):
+        await asyncio.to_thread(self._write_json, data)
+
+    async def run(self, args: str) -> str:
+        args = args.strip()
+        reminders = await self._load()
+        if not args or args.lower() == "list":
+            if not reminders:
+                return "[Lex] No reminders saved."
+            return "\n".join(f"- {r}" for r in reminders)
+        reminders.append(args)
+        await self._save(reminders)
+        return f"[Lex] Reminder saved: {args}"

--- a/commands/weather.py
+++ b/commands/weather.py
@@ -1,0 +1,18 @@
+class Command:
+    trigger = ["weather"]
+
+    def __init__(self, context):
+        self.context = context
+        self.settings = context.get("settings", {})
+
+    async def run(self, args: str) -> str:
+        location = args.strip() or "your area"
+        if not self.settings.get("use_cloud"):
+            return f"[Lex] It's probably fine outside in {location}."
+        import asyncio, requests
+        url = f"https://wttr.in/{location}?format=3"
+        try:
+            resp = await asyncio.to_thread(requests.get, url, timeout=5)
+            return resp.text.strip()
+        except Exception as e:
+            return f"[Lex] Couldn't fetch weather: {e}"


### PR DESCRIPTION
## Summary
- add `define` command that fetches definitions only when cloud usage is enabled
- add `weather` command with optional API usage
- add `remind` command that saves reminders to `memory/reminders.json`

## Testing
- `python - <<'EOF'
import asyncio
from core.settings import load_settings
from dispatcher import Dispatcher
async def run():
    dp = Dispatcher({"settings": load_settings()})
    print(await dp.dispatch("define test"))
    print(await dp.dispatch("weather"))
    print(await dp.dispatch("remind buy milk"))
    print(await dp.dispatch("remind list"))
asyncio.run(run())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68400172a37c832fa1bd46e20f6873e5