### PR TITLE
Add help command module

### DIFF
--- a/commands/help.py
+++ b/commands/help.py
@@ -1,0 +1,21 @@
+class Command:
+    trigger = ["help"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        dispatcher = self.context.get("dispatcher")
+        if not dispatcher:
+            return "[Lex] Dispatcher not available."
+
+        triggers = []
+        for cmd in dispatcher.commands:
+            trig = getattr(cmd, "trigger", [])
+            if isinstance(trig, (list, tuple)):
+                triggers.extend(trig)
+        if not triggers:
+            return "[Lex] No commands loaded."
+        unique = sorted(set(triggers))
+        return "[Lex] Available commands: " + ", ".join(unique)
+

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -6,6 +6,7 @@ from typing import List
 class Dispatcher:
     def __init__(self, context: dict | None = None):
         self.context = context or {}
+        self.context["dispatcher"] = self
         self.commands: List[object] = []
         self.load_modules()
 


### PR DESCRIPTION
## Summary
- add `help` command to list available triggers
- expose dispatcher through context for plugin access

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684001732a20832fa6f8f11f0620f5a0