### PR TITLE
Add NLP pre-parser for natural phrases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Lex is a **modular, locally running assistant** designed to:
 - ✅ Async command processing (non-blocking CLI loop)
 - ✅ Config loader with default injection (`settings.json`)
 - ✅ Fully offline (unless using `define`, which pings an API)
+- ✅ Basic natural language parsing for common phrases
 
 ### Example Commands
 - ✅ `remind me in X minutes to Y` (persistent reminders)
@@ -33,6 +34,7 @@ Lex is a **modular, locally running assistant** designed to:
 - ✅ `define <word>` (real API based)
 - ✅ `weather` (mocked for now)
 - ✅ `vault` with AES encryption, master password, and CRUD ops
+- ✅ Natural phrasing like "remind me to drink" or "what's the weather"
 
 ---
 

--- a/core/nlp.py
+++ b/core/nlp.py
@@ -1,0 +1,25 @@
+import re
+
+# Simple patterns to convert natural phrases into Lex commands
+PATTERNS: list[tuple[re.Pattern[str], callable]] = [
+    (re.compile(r"^remind me to (.+)", re.I), lambda m: f"remind {m.group(1)}"),
+    (re.compile(r"^set a reminder for (.+)", re.I), lambda m: f"remind {m.group(1)}"),
+    (re.compile(r"^tell me to (.+)", re.I), lambda m: f"remind {m.group(1)}"),
+    (re.compile(r"^what(?:'s| is) the weather(?: in| for)?\s*(.*)", re.I), lambda m: f"weather {m.group(1).strip()}"),
+    (re.compile(r"^flip a coin", re.I), lambda m: "game flip"),
+    (re.compile(r"^roll (?:a )?dice", re.I), lambda m: "game roll"),
+    (re.compile(r"^roll a die", re.I), lambda m: "game roll"),
+    (re.compile(r"^generate a uuid", re.I), lambda m: "tools uuid"),
+    (re.compile(r"^generate a password(?: of length)? (\d+)", re.I), lambda m: f"tools password {m.group(1)}"),
+    (re.compile(r"^generate a password", re.I), lambda m: "tools password"),
+]
+
+
+def normalize_input(text: str) -> str:
+    """Return a canonical command string from natural language."""
+    cleaned = text.strip()
+    for pattern, func in PATTERNS:
+        match = pattern.match(cleaned)
+        if match:
+            return func(match).strip()
+    return cleaned

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -2,6 +2,8 @@ import importlib
 import pkgutil
 from typing import List
 
+from core.nlp import normalize_input
+
 
 class Dispatcher:
     def __init__(self, context: dict | None = None):
@@ -30,12 +32,14 @@ class Dispatcher:
                 print(f"[Lex] ERROR loading {module_name}: {e}")
 
     async def dispatch(self, input_text: str):
-        lowered = input_text.lower()
+        """Route the given text to the appropriate command."""
+        text = normalize_input(input_text)
+        lowered = text.lower()
         for cmd in self.commands:
             triggers = getattr(cmd, "trigger", [])
             for trig in triggers:
                 if lowered.startswith(trig):
-                    args = input_text[len(trig):].strip()
+                    args = text[len(trig):].strip()
                     try:
                         return await cmd.run(args)
                     except Exception as e:


### PR DESCRIPTION
## Summary
- allow natural language like "Remind me to drink" or "What's the weather" to map to commands
- document natural phrase support

## Testing
- `python lexd.py <<'EOF'
Remind me to drink water
what's the weather
flip a coin
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68400334d930832fa7fb89adbbd4d421