### PR TITLE
Improve vault concurrency and tests

### DIFF
--- a/tests/test_commands/test_vault.py
+++ b/tests/test_commands/test_vault.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+from commands.vault import Command
+
+@pytest.mark.asyncio
+async def test_vault_basic(tmp_path):
+    cmd = Command({})
+    cmd.file = tmp_path / "vault.json"
+
+    resp = await cmd.run("list")
+    assert "empty" in resp
+
+    await cmd.run("set foo bar")
+    assert os.path.exists(cmd.file)
+
+    value = await cmd.run("get foo")
+    assert value == "bar"
+
+    resp = await cmd.run("list")
+    assert "foo" in resp
+


### PR DESCRIPTION
## Summary
- make vault file path overridable and guard reads/writes with `asyncio.Lock`
- perform file I/O in a thread to keep event loop responsive
- test vault CRUD behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684011e1efac832fb8af616064911fc7