### PR TITLE
Optimize whisper transcription

### DIFF
--- a/lexd.py
+++ b/lexd.py
@@ -16,7 +16,7 @@ async def main() -> None:
     while True:
         if settings.get("voice_input"):
             try:
-                cmd = transcribe()
+                cmd = await transcribe()
                 print(f"> {cmd}")
             except Exception as e:
                 print(f"[Lex] Voice input error: {e}")

--- a/voice/recognizer.py
+++ b/voice/recognizer.py
@@ -1,24 +1,49 @@
 import os
+import asyncio
+from tempfile import NamedTemporaryFile
 import speech_recognition as sr
 
+_whisper_model = None
 
-def transcribe(timeout: int | None = None) -> str:
+
+async def _get_whisper_model():
+    """Load and cache the Whisper model."""
+    global _whisper_model
+    if _whisper_model is None:
+        try:
+            import whisper
+            _whisper_model = await asyncio.to_thread(whisper.load_model, "base")
+        except Exception:
+            _whisper_model = False  # Flag to avoid retrying
+    return _whisper_model
+
+
+async def transcribe(timeout: int | None = None) -> str:
     """Listen from the microphone and return recognized text."""
     recognizer = sr.Recognizer()
     with sr.Microphone() as source:
-        audio = recognizer.listen(source, timeout=timeout)
+        audio = await asyncio.to_thread(recognizer.listen, source, timeout=timeout)
+
     try:
         return recognizer.recognize_sphinx(audio)
     except (sr.UnknownValueError, sr.RequestError):
         pass
-    # Fallback to whisper if installed and speech_recognition failed
+
+    model = await _get_whisper_model()
+    if not model:
+        return ""
+
+    tmp_file = NamedTemporaryFile(suffix=".wav", delete=False)
+    tmp_path = tmp_file.name
     try:
-        import whisper
-        model = whisper.load_model("base")
-        with open("_tmp.wav", "wb") as fh:
-            fh.write(audio.get_wav_data())
-        result = model.transcribe("_tmp.wav")
-        os.remove("_tmp.wav")
+        tmp_file.write(audio.get_wav_data())
+        tmp_file.close()
+        result = await asyncio.to_thread(model.transcribe, tmp_path)
         return result.get("text", "").strip()
     except Exception:
         return ""
+    finally:
+        try:
+            os.remove(tmp_path)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- cache whisper model at module scope
- clean up temp files using `NamedTemporaryFile`
- offload whisper call to a thread and make transcription async
- call transcribe asynchronously in daemon loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684011e5e2d4832f85ea7bff17d7cbf4