### PR TITLE
Enable voice transcription in lexd loop

### DIFF
--- a/lexd.py
+++ b/lexd.py
@@ -16,6 +16,7 @@ async def main() -> None:
     while True:
         if settings.get("voice_input"):
             try:
+                cmd = await transcribe(5)
                 print(f"> {cmd}")
             except Exception as e:
                 print(f"[Lex] Voice input error: {e}")


### PR DESCRIPTION
## Summary
- call `transcribe()` inside `lexd`'s loop when voice input is enabled

## Testing
- `pytest -q`
- `python lexd.py` with `voice_input` disabled

------
https://chatgpt.com/codex/tasks/task_e_684016f5f0cc832fb845fa17e0b7af36