### PR TITLE
Add tests for vault command

### DIFF
--- a/tests/test_commands/test_vault.py
+++ b/tests/test_commands/test_vault.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+
+from commands import vault
+
+
+@pytest.mark.asyncio
+async def test_vault_set_get_and_list(tmp_path, monkeypatch):
+    test_file = tmp_path / "vault.json"
+    monkeypatch.setattr(vault, "VAULT_FILE", str(test_file))
+
+    cmd = vault.Command({})
+    assert cmd.file == str(test_file)
+
+    resp = await cmd.run("set foo bar")
+    assert "Stored" in resp
+
+    value = await cmd.run("get foo")
+    assert value == "bar"
+
+    keys = await cmd.run("list")
+    assert "foo" in keys


### PR DESCRIPTION
## Summary
- test storing and retrieving values via the `vault` command
- ensure vault list shows stored keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684016f3cd80832fb1e4dcd64f788cbb