### PR TITLE
Optimize dispatcher trigger lookup

### DIFF
--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -7,7 +7,15 @@ from dispatcher import Dispatcher
 @pytest.mark.asyncio
 async def test_dispatcher_ping():
     dispatcher = Dispatcher({"settings": load_settings()})
+    assert "ping" in dispatcher.trigger_map
     resp = await dispatcher.dispatch("ping")
+    assert "Pong" in resp
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_alias():
+    dispatcher = Dispatcher({"settings": load_settings()})
+    resp = await dispatcher.dispatch("are you alive")
     assert "Pong" in resp
 
 


### PR DESCRIPTION
## Summary
- map command triggers during module load for quick lookup
- simplify dispatch loop to use new trigger map
- extend dispatcher tests for trigger map and alias dispatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684016f2d598832f9126c8bfa64c1815