### PR TITLE
Update vault docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Lex is a **modular, locally running assistant** designed to:
 - ✅ `flip a coin`, `roast me`, `compliment me`
 - ✅ `define <word>` (real API based)
 - ✅ `weather` (mocked for now)
-- ✅ `vault` with AES encryption, master password, and CRUD ops
+- ✅ `vault` with simple JSON storage for CRUD ops (no encryption yet)
 - ✅ Natural phrasing like "remind me to drink" or "what's the weather"
 
 ---

--- a/tests/test_commands/test_vault.py
+++ b/tests/test_commands/test_vault.py
@@ -1,0 +1,26 @@
+import pytest
+
+from commands.vault import Command
+
+
+@pytest.mark.asyncio
+async def test_vault_set_and_get(tmp_path):
+    cmd = Command({})
+    cmd.file = tmp_path / "vault.json"
+
+    resp = await cmd.run("set foo bar")
+    assert "Stored" in resp
+
+    result = await cmd.run("get foo")
+    assert result == "bar"
+
+
+@pytest.mark.asyncio
+async def test_vault_list(tmp_path):
+    cmd = Command({})
+    cmd.file = tmp_path / "vault.json"
+
+    await cmd.run("set alpha beta")
+    listing = await cmd.run("list")
+    assert "alpha" in listing
+


### PR DESCRIPTION
## Summary
- correct README to describe JSON vault
- add tests verifying vault CRUD behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684016e1eb38832f995fe1ed2d2134ea