### PR TITLE
Fix voice input command capture

### DIFF
--- a/lexd.py
+++ b/lexd.py
@@ -16,6 +16,7 @@ async def main() -> None:
     while True:
         if settings.get("voice_input"):
             try:
+                cmd = await transcribe()
                 print(f"> {cmd}")
             except Exception as e:
                 print(f"[Lex] Voice input error: {e}")


### PR DESCRIPTION
## Summary
- use `transcribe()` when voice input is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684016dc4e18832f91316b9232f400dc