### PR TITLE
Add learning NLP feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Lex is a **modular, locally running assistant** designed to:
 - ✅ `weather` (mocked for now)
 - ✅ `vault` with passphrase-encrypted storage
 - ✅ Natural phrasing like "can you remind me to drink" or "how's the weather"
+- ✅ Teach Lex new phrases with `learn <phrase> as <command>`
 
 ---
 

--- a/commands/learn.py
+++ b/commands/learn.py
@@ -1,0 +1,30 @@
+import asyncio
+from core import nlp
+
+
+class Command:
+    trigger = ["learn", "teach"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        args = args.strip()
+        if args == "list":
+            custom = await asyncio.to_thread(nlp.get_custom_intents)
+            if not custom:
+                return "[Lex] I haven't learned anything yet."
+            return "\n".join(f"{k} -> {v}" for k, v in custom.items())
+
+        if " as " not in args:
+            return "[Lex] Usage: learn <phrase> as <command>"
+
+        phrase, command = args.split(" as ", 1)
+        phrase = phrase.strip()
+        command = command.strip()
+        if not phrase or not command:
+            return "[Lex] Usage: learn <phrase> as <command>"
+
+        await asyncio.to_thread(nlp.add_custom_intent, phrase, command)
+        return f"[Lex] Learned '{phrase}' -> '{command}'"
+

--- a/tests/test_commands/test_learn.py
+++ b/tests/test_commands/test_learn.py
@@ -1,0 +1,24 @@
+import pytest
+
+from commands.learn import Command
+from dispatcher import Dispatcher
+from core.settings import load_settings
+from core import nlp
+
+
+@pytest.mark.asyncio
+async def test_learn_custom_phrase(tmp_path, monkeypatch):
+    custom_file = tmp_path / "custom.json"
+    monkeypatch.setattr(nlp, "CUSTOM_INTENTS_FILE", str(custom_file))
+    # reset caches and registry
+    nlp._custom_cache = None
+    nlp._refresh_custom_registry()
+
+    cmd = Command({})
+    resp = await cmd.run("hello there as ping")
+    assert "Learned" in resp
+
+    dispatcher = Dispatcher({"settings": load_settings()})
+    result = await dispatcher.dispatch("hello there")
+    assert "Pong" in result
+


### PR DESCRIPTION
## Summary
- allow Lex to learn custom phrases via a new `learn` command
- store learned phrases under `memory/custom_intents.json`
- extend NLP to load and apply user-defined intents
- document the new feature in the README
- test learning flow with a new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840279c30c4832fb2d683aa331205e1