### PR TITLE
Add machine learning NLP with corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Thumbs.db
 # Lex-specific
 memory/*.json
 settings.json  # If you want to prevent your local settings from being committed
+models/
+data/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ SpeechRecognition
 pyttsx3
 pytest
 pytest-asyncio
+scikit-learn
+joblib


### PR DESCRIPTION
## Summary
- ignore persistent models and training data
- install scikit-learn and joblib
- implement ML intent classifier with updateable training data
- keep regex fallback and custom intents
- include inline tests demonstrating learning

## Testing
- `pip install -q scikit-learn joblib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684028c5244c832fa462da9ce003e1d7