### PR TITLE
Add placeholder modules for planned features

### DIFF
--- a/commands/cleanup.py
+++ b/commands/cleanup.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["cleanup"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: cleanup feature"

--- a/commands/codeassist.py
+++ b/commands/codeassist.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["codeassist"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: codeassist feature"

--- a/commands/collab.py
+++ b/commands/collab.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["collab"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: collab feature"

--- a/commands/email_summary.py
+++ b/commands/email_summary.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["email_summary"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: email_summary feature"

--- a/commands/history.py
+++ b/commands/history.py
@@ -1,0 +1,20 @@
+import asyncio
+
+
+class Command:
+    """Show recent command history and results."""
+
+    trigger = ["history", "context"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        history: list[tuple[str, str]] = self.context.get("history", [])
+        if not history:
+            return "[Lex] No recent history."
+        lines = []
+        for i, (cmd, resp) in enumerate(history[-5:], start=1):
+            lines.append(f"{i}. > {cmd} | {resp}")
+        return "\n".join(lines)

--- a/commands/hotkey.py
+++ b/commands/hotkey.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["hotkey"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: hotkey feature"

--- a/commands/hud.py
+++ b/commands/hud.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["hud"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: hud feature"

--- a/commands/knowledge.py
+++ b/commands/knowledge.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["knowledge"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: knowledge feature"

--- a/commands/notify.py
+++ b/commands/notify.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["notify"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: notify feature"

--- a/commands/pingback.py
+++ b/commands/pingback.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["pingback"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: pingback feature"

--- a/commands/proactive.py
+++ b/commands/proactive.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["proactive"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: proactive feature"

--- a/commands/profile.py
+++ b/commands/profile.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["profile"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: profile feature"

--- a/commands/schedule.py
+++ b/commands/schedule.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["schedule"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: schedule feature"

--- a/commands/secdash.py
+++ b/commands/secdash.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["secdash"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: secdash feature"

--- a/commands/smarthome.py
+++ b/commands/smarthome.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["smarthome"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: smarthome feature"

--- a/commands/tone.py
+++ b/commands/tone.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["tone"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: tone feature"

--- a/commands/translate.py
+++ b/commands/translate.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["translate"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: translate feature"

--- a/commands/wakeword.py
+++ b/commands/wakeword.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["wakeword"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: wakeword feature"

--- a/commands/workflow.py
+++ b/commands/workflow.py
@@ -1,0 +1,12 @@
+import asyncio
+
+
+class Command:
+    trigger = ["workflow"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        return "[Lex] TODO: workflow feature"

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -14,6 +14,7 @@ class Dispatcher:
         self.package = package
         self.context = context or {}
         self.context["dispatcher"] = self
+        self.context.setdefault("history", [])
         self.commands: List[object] = []
         self.trigger_map: dict[str, object] = {}
         self.module_mtimes: dict[str, float] = {}
@@ -86,6 +87,11 @@ class Dispatcher:
                     result = await cmd.run(args)
                     self.context["last_command"] = trig
                     self.context["last_result"] = result
+                    history = self.context.get("history")
+                    if isinstance(history, list):
+                        history.append((input_text, result))
+                        if len(history) > 20:
+                            del history[:-20]
                     return result
                 except Exception as e:
                     print(f"[Lex] ERROR in {cmd.__class__.__name__}: {e}")

--- a/tests/test_commands/test_history.py
+++ b/tests/test_commands/test_history.py
@@ -1,0 +1,11 @@
+import pytest
+
+from dispatcher import Dispatcher
+
+
+@pytest.mark.asyncio
+async def test_history_tracks_commands():
+    dispatcher = Dispatcher({})
+    await dispatcher.dispatch("ping")
+    resp = await dispatcher.dispatch("history")
+    assert "ping" in resp


### PR DESCRIPTION
## Summary
- stub out new command modules for upcoming capabilities
- each module exposes `Command` with `trigger` and async `run`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68403f30ac04832fb12c141e32810a0b