### PR TITLE
Implement cleanup, pingback and profile plugins

### DIFF
--- a/commands/cleanup.py
+++ b/commands/cleanup.py
@@ -1,12 +1,47 @@
 import asyncio
+import os
+import shutil
+from pathlib import Path
 
 
 class Command:
+    """Simple disk cleanup utilities."""
+
     trigger = ["cleanup"]
 
     def __init__(self, context):
         self.context = context
 
+    def _remove_tmp(self, root: Path) -> int:
+        count = 0
+        for path in root.rglob("*.tmp"):
+            try:
+                path.unlink()
+                count += 1
+            except Exception:
+                pass
+        return count
+
+    def _remove_pycache(self, root: Path) -> int:
+        count = 0
+        for cache in root.rglob("__pycache__"):
+            shutil.rmtree(cache, ignore_errors=True)
+            count += 1
+        for pyc in root.rglob("*.pyc"):
+            try:
+                pyc.unlink()
+                count += 1
+            except Exception:
+                pass
+        return count
+
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: cleanup feature"
+        option = args.strip().lower()
+        root = Path(".")
+        if option == "pycache":
+            removed = await asyncio.to_thread(self._remove_pycache, root)
+            return f"[Lex] Removed {removed} pycache items."
+
+        removed = await asyncio.to_thread(self._remove_tmp, root)
+        return f"[Lex] Removed {removed} .tmp files."

--- a/commands/pingback.py
+++ b/commands/pingback.py
@@ -1,7 +1,10 @@
 import asyncio
+import platform
 
 
 class Command:
+    """Check network reachability for a host."""
+
     trigger = ["pingback"]
 
     def __init__(self, context):
@@ -9,4 +12,17 @@ class Command:
 
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: pingback feature"
+        host = args.strip() or "8.8.8.8"
+        flag = "-n" if platform.system() == "Windows" else "-c"
+        proc = await asyncio.create_subprocess_exec(
+            "ping",
+            flag,
+            "1",
+            host,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+        if proc.returncode == 0:
+            return f"[Lex] {host} is reachable."
+        return f"[Lex] {host} unreachable."

--- a/commands/profile.py
+++ b/commands/profile.py
@@ -1,12 +1,57 @@
 import asyncio
+import json
+import os
+from pathlib import Path
+
+
+PROFILE_FILE = Path("memory") / "profile.json"
 
 
 class Command:
+    """Manage a simple local user profile."""
+
     trigger = ["profile"]
 
     def __init__(self, context):
         self.context = context
+        self.file = PROFILE_FILE
+        self.lock = asyncio.Lock()
+
+    def _load(self) -> dict:
+        if self.file.exists():
+            try:
+                with self.file.open("r", encoding="utf-8") as fh:
+                    return json.load(fh)
+            except Exception:
+                pass
+        return {}
+
+    def _save(self, data: dict) -> None:
+        os.makedirs(self.file.parent, exist_ok=True)
+        with self.file.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
 
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: profile feature"
+        tokens = args.split(maxsplit=2)
+        async with self.lock:
+            profile = await asyncio.to_thread(self._load)
+
+            if not tokens or tokens[0] == "show":
+                if not profile:
+                    return "[Lex] Profile empty."
+                return "\n".join(f"{k}: {v}" for k, v in profile.items())
+
+            if tokens[0] == "set" and len(tokens) == 3:
+                profile[tokens[1]] = tokens[2]
+                await asyncio.to_thread(self._save, profile)
+                return "[Lex] Profile updated."
+
+            if tokens[0] == "delete" and len(tokens) == 2:
+                if tokens[1] in profile:
+                    del profile[tokens[1]]
+                    await asyncio.to_thread(self._save, profile)
+                    return "[Lex] Deleted."
+                return "[Lex] Not found."
+
+            return "[Lex] Use 'profile show', 'profile set <key> <val>' or 'profile delete <key>'."

--- a/documentation.md
+++ b/documentation.md
@@ -6,7 +6,7 @@ implementation.
 
 | Plugin | Triggers | Description |
 |-------|----------|-------------|
-| cleanup.py | `cleanup` | Placeholder for future system clean up tasks. |
+| cleanup.py | `cleanup` | Remove `.tmp` files or clear Python caches. |
 | clipboard.py | `clipboard` | Maintain a simple clipboard history (add, show, paste, clear). |
 | codeassist.py | `codeassist` | Placeholder for coding assistance features. |
 | collab.py | `collab` | Placeholder for collaboration utilities. |
@@ -26,9 +26,9 @@ implementation.
 | notify.py | `notify` | Placeholder for desktop notifications. |
 | personality.py | `personality` | Get or set sarcasm level. |
 | ping.py | `ping`, `are you alive` | Respond with a simple "Pong" message. |
-| pingback.py | `pingback` | Placeholder for network reachability checks. |
+| pingback.py | `pingback` | Check if a host is reachable via `ping`. |
 | proactive.py | `proactive` | Placeholder for proactive suggestions. |
-| profile.py | `profile` | Placeholder for user profile management. |
+| profile.py | `profile` | Manage a simple local profile (`show`, `set`, `delete`). |
 | remind.py | `remind` | Store and list reminders. |
 | schedule.py | `schedule` | Manage dated events in a small local schedule. |
 | search.py | `search`, `find`, `locate` | Search files from a local index. |

--- a/todo.md
+++ b/todo.md
@@ -2,7 +2,6 @@
 
 The following command modules contain only placeholder implementations and need full features implemented:
 
-- commands/cleanup.py
 - commands/codeassist.py
 - commands/collab.py
 - commands/email_summary.py
@@ -10,9 +9,7 @@ The following command modules contain only placeholder implementations and need 
 - commands/hud.py
 - commands/knowledge.py
 - commands/notify.py
-- commands/pingback.py
 - commands/proactive.py
-- commands/profile.py
 - commands/secdash.py
 - commands/smarthome.py
 - commands/translate.py


### PR DESCRIPTION
## Summary
- implement cleanup plugin to remove temp and pycache files
- implement pingback plugin to check host reachability
- implement profile plugin for local profile data
- document these plugins
- update TODO list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840484c7094832fa125bdc629f1faed