### PR TITLE
Implement codeassist, knowledge and translate plugins

### DIFF
--- a/commands/codeassist.py
+++ b/commands/codeassist.py
@@ -1,7 +1,27 @@
+"""Offline code snippet helper."""
+
 import asyncio
 
 
+SNIPPETS: dict[str, str] = {
+    "csv": (
+        "import csv\n\n"
+        "with open('file.csv', newline='') as fh:\n"
+        "    reader = csv.DictReader(fh)\n"
+        "    for row in reader:\n"
+        "        print(row)"
+    ),
+    "http server": (
+        "from http.server import HTTPServer, SimpleHTTPRequestHandler\n\n"
+        "server = HTTPServer(('0.0.0.0', 8000), SimpleHTTPRequestHandler)\n"
+        "server.serve_forever()"
+    ),
+}
+
+
 class Command:
+    """Return small code snippets for common tasks."""
+
     trigger = ["codeassist"]
 
     def __init__(self, context):
@@ -9,4 +29,13 @@ class Command:
 
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: codeassist feature"
+        query = args.strip().lower()
+        if not query or query == "list":
+            names = ", ".join(sorted(SNIPPETS))
+            return f"[Lex] Available snippets: {names}"
+
+        snippet = SNIPPETS.get(query)
+        if snippet:
+            return snippet
+
+        return "[Lex] No snippet for that topic. Try 'codeassist list'."

--- a/commands/knowledge.py
+++ b/commands/knowledge.py
@@ -1,12 +1,41 @@
+"""Search local documentation for answers."""
+
 import asyncio
+from pathlib import Path
+
+
+DOC_FILES = [Path("README.md"), Path("documentation.md"), Path("What they do")]
 
 
 class Command:
+    """Simple knowledge base query from bundled docs."""
+
     trigger = ["knowledge"]
 
     def __init__(self, context):
         self.context = context
+        self.files = [p for p in DOC_FILES if p.exists()]
 
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: knowledge feature"
+        query = args.strip().lower()
+        if not query:
+            return "[Lex] Ask me about something in the docs."
+
+        matches: list[str] = []
+        for file in self.files:
+            try:
+                with file.open("r", encoding="utf-8") as fh:
+                    for i, line in enumerate(fh, 1):
+                        if query in line.lower():
+                            matches.append(f"{file.name}:{i}: {line.strip()}")
+                            if len(matches) >= 3:
+                                break
+            except Exception:
+                continue
+            if len(matches) >= 3:
+                break
+
+        if not matches:
+            return "[Lex] Nothing found."
+        return "\n".join(matches)

--- a/commands/translate.py
+++ b/commands/translate.py
@@ -1,4 +1,13 @@
+"""Translate short text between languages."""
+
 import asyncio
+
+
+OFFLINE_DICT = {
+    ("hello", "es"): "hola",
+    ("goodbye", "es"): "adios",
+    ("hola", "en"): "hello",
+}
 
 
 class Command:
@@ -6,7 +15,35 @@ class Command:
 
     def __init__(self, context):
         self.context = context
+        self.settings = context.get("settings", {})
 
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: translate feature"
+        tokens = args.split()
+        if len(tokens) < 2:
+            return "[Lex] Use 'translate <lang> <text>'."
+
+        lang = tokens[0]
+        text = " ".join(tokens[1:])
+
+        if not text:
+            return "[Lex] Nothing to translate."
+
+        if not self.settings.get("use_cloud"):
+            match = OFFLINE_DICT.get((text.lower(), lang))
+            if match:
+                return match
+            return (
+                "[Lex] Offline dictionary is limited. Enable cloud for more langu" "ages."
+            )
+
+        try:
+            from deep_translator import GoogleTranslator
+        except Exception as e:
+            return f"[Lex] Translation unavailable: {e}"
+
+        try:
+            translator = GoogleTranslator(source="auto", target=lang)
+            return await asyncio.to_thread(translator.translate, text)
+        except Exception as e:
+            return f"[Lex] Translation failed: {e}"

--- a/documentation.md
+++ b/documentation.md
@@ -8,7 +8,7 @@ implementation.
 |-------|----------|-------------|
 | cleanup.py | `cleanup` | Remove `.tmp` files or clear Python caches. |
 | clipboard.py | `clipboard` | Maintain a simple clipboard history (add, show, paste, clear). |
-| codeassist.py | `codeassist` | Placeholder for coding assistance features. |
+| codeassist.py | `codeassist` | Return handy Python code snippets for common tasks. |
 | collab.py | `collab` | Placeholder for collaboration utilities. |
 | define.py | `define` | Look up word definitions using a web API when cloud access is allowed. |
 | email_summary.py | `email_summary` | Placeholder to summarize new emails. |
@@ -20,7 +20,7 @@ implementation.
 | hotkey.py | `hotkey` | Placeholder for custom hotkey support. |
 | hud.py | `hud` | Placeholder for heads-up display features. |
 | info.py | `info` | Display loaded commands and current settings. |
-| knowledge.py | `knowledge` | Placeholder for knowledge base queries. |
+| knowledge.py | `knowledge` | Search local documentation for matching lines. |
 | learn.py | `learn`, `teach` | Teach Lex new phrases that map to commands. |
 | notes.py | `notes`, `note` | Store short notes locally. |
 | notify.py | `notify` | Placeholder for desktop notifications. |
@@ -37,7 +37,7 @@ implementation.
 | system.py | `system` | Show basic system information. |
 | tone.py | `tone` | Adjust voice name, rate and pitch. |
 | tools.py | `tools` | Generate UUIDs or random passwords. |
-| translate.py | `translate` | Placeholder for text translation. |
+| translate.py | `translate` | Translate text using a small offline dictionary or cloud API. |
 | vault.py | `vault` | Store or retrieve key/value pairs, optionally encrypted. |
 | wakeword.py | `wakeword` | Placeholder to configure wake words. |
 | weather.py | `weather` | Return a weather report (cloud or local). |

--- a/todo.md
+++ b/todo.md
@@ -2,16 +2,13 @@
 
 The following command modules contain only placeholder implementations and need full features implemented:
 
-- commands/codeassist.py
 - commands/collab.py
 - commands/email_summary.py
 - commands/hotkey.py
 - commands/hud.py
-- commands/knowledge.py
 - commands/notify.py
 - commands/proactive.py
 - commands/secdash.py
 - commands/smarthome.py
-- commands/translate.py
 - commands/wakeword.py
 - commands/workflow.py


### PR DESCRIPTION
## Summary
- fill in codeassist plugin with offline snippets
- implement basic knowledge base search from docs
- add translate plugin using offline dictionary and optional cloud
- update plugin overview in docs
- update todo list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684049d414f8832f993e7480e5e2bd89