### PR TITLE
Implement HUD, Hotkey, and Workflow plugins

### DIFF
--- a/commands/hotkey.py
+++ b/commands/hotkey.py
@@ -1,12 +1,139 @@
 import asyncio
+import json
+import os
+from pathlib import Path
+
+
+HOTKEY_FILE = Path("memory") / "hotkeys.json"
 
 
 class Command:
+    """Register and manage global hotkeys."""
+
     trigger = ["hotkey"]
 
     def __init__(self, context):
         self.context = context
+        self.file = HOTKEY_FILE
+        self.hotkeys: dict[str, str] = {}
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.keyboard = None
+        self.active = False
+        self._load()
 
+    # ---------------------------------------------------------
+    # Persistence helpers
+    # ---------------------------------------------------------
+    def _load(self) -> None:
+        if self.file.exists():
+            try:
+                with self.file.open("r", encoding="utf-8") as fh:
+                    self.hotkeys = json.load(fh)
+            except Exception:
+                self.hotkeys = {}
+
+    def _save(self) -> None:
+        os.makedirs(self.file.parent, exist_ok=True)
+        with self.file.open("w", encoding="utf-8") as fh:
+            json.dump(self.hotkeys, fh)
+
+    # ---------------------------------------------------------
+    # Hotkey handling helpers
+    # ---------------------------------------------------------
+    def _callback(self, command: str):
+        def inner() -> None:
+            if not self.active or not self.loop:
+                return
+            dispatcher = self.context.get("dispatcher")
+            if not dispatcher:
+                return
+            asyncio.run_coroutine_threadsafe(
+                dispatcher.dispatch(command), self.loop
+            )
+
+        return inner
+
+    def _register_all(self) -> None:
+        if not self.keyboard:
+            return
+        for combo, cmd in self.hotkeys.items():
+            self.keyboard.add_hotkey(combo, self._callback(cmd))
+
+    def start_listener(self, loop: asyncio.AbstractEventLoop) -> str:
+        if self.active:
+            return "[Lex] Hotkey listener already running."
+        try:
+            import keyboard
+
+            self.keyboard = keyboard
+        except Exception:
+            return "[Lex] 'keyboard' package not installed."
+
+        self.loop = loop
+        self._register_all()
+        self.active = True
+        return "[Lex] Hotkey listener started."
+
+    def stop_listener(self) -> str:
+        if not self.active:
+            return "[Lex] Hotkey listener not running."
+        if self.keyboard:
+            try:
+                self.keyboard.clear_all_hotkeys()
+            except Exception:
+                pass
+        self.active = False
+        return "[Lex] Hotkey listener stopped."
+
+    # ---------------------------------------------------------
+    # Command entry point
+    # ---------------------------------------------------------
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: hotkey feature"
+        tokens = args.split()
+        if not tokens:
+            return (
+                "[Lex] Use 'hotkey add <combo> <command>', 'remove <combo>', "
+                "'list', 'start', or 'stop'."
+            )
+
+        cmd = tokens[0]
+
+        if cmd == "list":
+            if not self.hotkeys:
+                return "[Lex] No hotkeys defined."
+            return "\n".join(f"{k} -> {v}" for k, v in self.hotkeys.items())
+
+        if cmd == "add" and len(tokens) >= 3:
+            combo = tokens[1]
+            command = " ".join(tokens[2:])
+            self.hotkeys[combo] = command
+            self._save()
+            if self.active and self.keyboard:
+                try:
+                    self.keyboard.add_hotkey(combo, self._callback(command))
+                except Exception:
+                    pass
+            return f"[Lex] Hotkey '{combo}' added."
+
+        if cmd == "remove" and len(tokens) >= 2:
+            combo = tokens[1]
+            if combo in self.hotkeys:
+                del self.hotkeys[combo]
+                self._save()
+                if self.active and self.keyboard:
+                    try:
+                        self.keyboard.remove_hotkey(combo)
+                    except Exception:
+                        pass
+                return f"[Lex] Removed hotkey '{combo}'."
+            return "[Lex] Hotkey not found."
+
+        if cmd == "start":
+            loop = asyncio.get_running_loop()
+            return self.start_listener(loop)
+
+        if cmd == "stop":
+            return self.stop_listener()
+
+        return "[Lex] Unknown hotkey command."

--- a/commands/hud.py
+++ b/commands/hud.py
@@ -1,12 +1,72 @@
 import asyncio
+import threading
+import tkinter as tk
+import psutil
 
 
 class Command:
+    """Toggle a simple system stats heads-up display."""
+
     trigger = ["hud"]
 
     def __init__(self, context):
         self.context = context
+        self.root: tk.Tk | None = None
+        self.thread: threading.Thread | None = None
+        self.running = False
 
+    # ---------------------------------------------------------
+    # GUI helpers
+    # ---------------------------------------------------------
+    def _update_label(self, label: tk.Label) -> None:
+        if not self.running:
+            return
+        cpu = psutil.cpu_percent(interval=None)
+        mem = psutil.virtual_memory().percent
+        label.config(text=f"CPU {cpu}% | MEM {mem}%")
+        if self.root:
+            self.root.after(1000, self._update_label, label)
+
+    def _run_gui(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("Lex HUD")
+        self.root.attributes("-topmost", True)
+        self.root.resizable(False, False)
+        label = tk.Label(self.root, text="", font=("Arial", 10))
+        label.pack(padx=10, pady=5)
+        self.running = True
+        self._update_label(label)
+        self.root.mainloop()
+        self.running = False
+
+    def _start_gui(self) -> None:
+        if self.thread and self.thread.is_alive():
+            return
+        self.thread = threading.Thread(target=self._run_gui, daemon=True)
+        self.thread.start()
+
+    def _stop_gui(self) -> None:
+        if self.root:
+            try:
+                self.running = False
+                self.root.after(0, self.root.destroy)
+            except Exception:
+                pass
+
+    # ---------------------------------------------------------
+    # Command entry point
+    # ---------------------------------------------------------
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: hud feature"
+        arg = args.strip().lower()
+        if arg in ("", "on", "start"):
+            if self.running:
+                return "[Lex] HUD already running."
+            self._start_gui()
+            return "[Lex] HUD started."
+        if arg in ("off", "stop"):
+            if not self.running:
+                return "[Lex] HUD not running."
+            self._stop_gui()
+            return "[Lex] HUD closed."
+        return "[Lex] Use 'hud on' or 'hud off'."

--- a/commands/workflow.py
+++ b/commands/workflow.py
@@ -1,12 +1,84 @@
 import asyncio
+import json
+import os
+from pathlib import Path
+
+
+WORKFLOW_FILE = Path("memory") / "workflows.json"
 
 
 class Command:
+    """Create and run simple multi-step workflows."""
+
     trigger = ["workflow"]
 
     def __init__(self, context):
         self.context = context
+        self.file = WORKFLOW_FILE
 
+    # ---------------------------------------------------------
+    # Persistence helpers
+    # ---------------------------------------------------------
+    def _load(self) -> dict[str, list[str]]:
+        if self.file.exists():
+            try:
+                with self.file.open("r", encoding="utf-8") as fh:
+                    return json.load(fh)
+            except Exception:
+                pass
+        return {}
+
+    def _save(self, data: dict[str, list[str]]) -> None:
+        os.makedirs(self.file.parent, exist_ok=True)
+        with self.file.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    # ---------------------------------------------------------
+    # Command entry point
+    # ---------------------------------------------------------
     async def run(self, args: str) -> str:
         await asyncio.sleep(0)
-        return "[Lex] TODO: workflow feature"
+        tokens = args.split(maxsplit=2)
+        if not tokens or tokens[0] == "list":
+            workflows = self._load()
+            if not workflows:
+                return "[Lex] No workflows defined."
+            lines = [f"{name}: {'; '.join(steps)}" for name, steps in workflows.items()]
+            return "\n".join(lines)
+
+        cmd = tokens[0]
+
+        if cmd == "create" and len(tokens) == 3:
+            name = tokens[1]
+            steps = [s.strip() for s in tokens[2].split(";") if s.strip()]
+            data = self._load()
+            data[name] = steps
+            self._save(data)
+            return f"[Lex] Workflow '{name}' saved."
+
+        if cmd == "run" and len(tokens) >= 2:
+            name = tokens[1]
+            data = self._load()
+            steps = data.get(name)
+            if not steps:
+                return f"[Lex] No workflow named '{name}'."
+            dispatcher = self.context.get("dispatcher")
+            if not dispatcher:
+                return "[Lex] Dispatcher not available."
+            for step in steps:
+                await dispatcher.dispatch(step)
+            return f"[Lex] Workflow '{name}' executed."
+
+        if cmd == "delete" and len(tokens) >= 2:
+            name = tokens[1]
+            data = self._load()
+            if name in data:
+                del data[name]
+                self._save(data)
+                return f"[Lex] Workflow '{name}' deleted."
+            return f"[Lex] No workflow named '{name}'."
+
+        return (
+            "[Lex] Use 'workflow create <name> cmd1; cmd2', 'run <name>', "
+            "'delete <name>' or 'list'."
+        )

--- a/documentation.md
+++ b/documentation.md
@@ -17,8 +17,6 @@ implementation.
 | health.py | `health`, `stats` | Report basic CPU, RAM and disk usage. |
 | help.py | `help` | List all available command triggers. |
 | history.py | `history`, `context` | Show recent command history and results. |
-| hotkey.py | `hotkey` | Placeholder for custom hotkey support. |
-| hud.py | `hud` | Placeholder for heads-up display features. |
 | info.py | `info` | Display loaded commands and current settings. |
 | knowledge.py | `knowledge` | Search local documentation for matching lines. |
 | learn.py | `learn`, `teach` | Teach Lex new phrases that map to commands. |
@@ -41,5 +39,7 @@ implementation.
 | vault.py | `vault` | Store or retrieve key/value pairs, optionally encrypted. |
 | wakeword.py | `wakeword` | Placeholder to configure wake words. |
 | weather.py | `weather` | Return a weather report (cloud or local). |
-| workflow.py | `workflow` | Placeholder for workflow automation. |
+| hotkey.py | `hotkey` | Register global hotkeys that trigger Lex commands. |
+| hud.py | `hud` | Show a small CPU and memory usage overlay window. |
+| workflow.py | `workflow` | Create and execute multi-step command workflows. |
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ joblib
 
 pyperclip
 psutil
+keyboard

--- a/todo.md
+++ b/todo.md
@@ -4,11 +4,8 @@ The following command modules contain only placeholder implementations and need 
 
 - commands/collab.py
 - commands/email_summary.py
-- commands/hotkey.py
-- commands/hud.py
 - commands/notify.py
 - commands/proactive.py
 - commands/secdash.py
 - commands/smarthome.py
 - commands/wakeword.py
-- commands/workflow.py


### PR DESCRIPTION
## Summary
- implement working `hotkey` plugin to register and manage global hotkeys
- add simple `hud` overlay for CPU and memory stats
- enable multi-step workflow creation and execution
- update documentation and TODO list
- include keyboard dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404bb530b0832fbec5d31951904fba