### PR TITLE
Improve NLP with fuzzy match support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Lex is a **modular, locally running assistant** designed to:
 - ✅ Passphrase-protected startup with encrypted vault
 - ✅ Fully offline (unless using `define`, which pings an API)
 - ✅ Expanded natural language parsing for common phrases
+- ✅ Fuzzy matching for misspelled commands
 - ✅ Optional voice input and text-to-speech output
 
 ### Example Commands

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -77,7 +77,7 @@ class Dispatcher:
 
     async def dispatch(self, input_text: str):
         """Route the given text to the appropriate command."""
-        text = normalize_input(input_text)
+        text = normalize_input(input_text, self.trigger_map.keys())
         lowered = text.lower()
 
         for trig, cmd in self.trigger_map.items():

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -67,3 +67,15 @@ async def test_dispatcher_features(tmp_path, monkeypatch):
     monkeypatch.setattr(features, "SUGGESTIONS_FILE", file)
     resp = await dispatcher.dispatch("what features are you missing")
     assert "brew coffee" in resp
+
+
+@pytest.mark.asyncio
+async def test_nlp_fuzzy_match(tmp_path):
+    settings = load_settings()
+    dispatcher = Dispatcher({"settings": settings})
+    for cmd in dispatcher.commands:
+        if hasattr(cmd, "file"):
+            cmd.file = tmp_path / "reminders_fuzzy.json"
+    # Intentionally misspelled command
+    resp = await dispatcher.dispatch("remmind me to sleep")
+    assert "Reminder saved" in resp


### PR DESCRIPTION
## Summary
- add fuzzy matching fallback in NLP module
- allow dispatcher to supply available triggers for fuzzy intent recognition
- update README to mention fuzzy matching
- add regression test for fuzzy command recognition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840504b0e64832faec21aaa7400f128