### PR TITLE
Fix fallback for empty voice transcription

### DIFF
--- a/lexd.py
+++ b/lexd.py
@@ -25,6 +25,8 @@ async def main() -> None:
                 # Pass optional duration if supported, fallback to default
                 cmd = await transcribe(settings.get("transcription_duration", 5))
                 logger.info("> %s", cmd)
+                if not cmd:
+                    cmd = (await asyncio.to_thread(input, "> ")).strip()
             except Exception as e:
                 logger.error("Voice input error: %s", e)
                 cmd = (await asyncio.to_thread(input, "> ")).strip()


### PR DESCRIPTION
## Summary
- fall back to text input when voice transcription returns nothing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406c7f2d38832f9ae717c1e1d4593e