### PR TITLE
Improve logging and plugin concurrency

### DIFF
--- a/commands/help.py
+++ b/commands/help.py
@@ -1,22 +1,54 @@
+import asyncio
+import re
+from pathlib import Path
+
+DOCS_FILE = Path("documentation.md")
+
+
 class Command:
     trigger = ["help"]
 
     def __init__(self, context):
         self.context = context
 
+    def _load_docs(self) -> dict[str, str]:
+        if not DOCS_FILE.exists():
+            return {}
+        info: dict[str, str] = {}
+        with DOCS_FILE.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if not line.startswith("|") or line.startswith("|---"):
+                    continue
+                parts = [p.strip() for p in line.strip().strip("|").split("|")]
+                if len(parts) < 3 or not parts[0].endswith(".py"):
+                    continue
+                triggers = [t.strip("` ") for t in parts[1].split(",")]
+                desc = parts[2]
+                for trig in triggers:
+                    if trig:
+                        info[trig] = desc
+        return info
+
     async def run(self, args: str) -> str:
-        """List all available command triggers."""
+        """List all available command triggers with descriptions."""
         dispatcher = self.context.get("dispatcher")
         if not dispatcher:
             return "[Lex] Dispatcher not available."
 
-        triggers = []
+        docs = await asyncio.to_thread(self._load_docs)
+        lines = []
         for cmd in dispatcher.commands:
-            trig = getattr(cmd, "trigger", [])
-            if isinstance(trig, (list, tuple)):
-                triggers.extend(trig)
-        if not triggers:
+            triggers = getattr(cmd, "trigger", [])
+            if not isinstance(triggers, (list, tuple)):
+                continue
+            desc = next((docs.get(t) for t in triggers if t in docs), "")
+            trig_list = ", ".join(triggers)
+            if desc:
+                lines.append(f"{trig_list} - {desc}")
+            else:
+                lines.append(trig_list)
+
+        if not lines:
             return "[Lex] No commands loaded."
-        unique = sorted(set(triggers))
-        return "[Lex] Available commands: " + ", ".join(unique)
+        return "[Lex] Available commands:\n" + "\n".join(sorted(lines))
 

--- a/commands/remind.py
+++ b/commands/remind.py
@@ -9,6 +9,7 @@ class Command:
     def __init__(self, context):
         self.context = context
         self.file = os.path.join("memory", "reminders.json")
+        self.lock = asyncio.Lock()
 
     def _read_json(self):
         if not os.path.exists(self.file):
@@ -32,11 +33,13 @@ class Command:
     async def run(self, args: str) -> str:
         """Store and list personal reminders."""
         args = args.strip()
-        reminders = await self._load()
+        async with self.lock:
+            reminders = await self._load()
         if not args or args.lower() == "list":
             if not reminders:
                 return "[Lex] No reminders saved."
             return "\n".join(f"- {r}" for r in reminders)
         reminders.append(args)
-        await self._save(reminders)
+        async with self.lock:
+            await self._save(reminders)
         return f"[Lex] Reminder saved: {args}"

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,4 +1,5 @@
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 
 LOG_FILE = os.path.join("logs", "lex.log")
@@ -14,7 +15,9 @@ def get_logger(name: str = "Lex") -> logging.Logger:
     os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
     formatter = logging.Formatter("[%(asctime)s] %(levelname)s:%(name)s:%(message)s")
 
-    file_handler = logging.FileHandler(LOG_FILE)
+    file_handler = RotatingFileHandler(
+        LOG_FILE, maxBytes=1_000_000, backupCount=3
+    )
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 

--- a/permissions.md
+++ b/permissions.md
@@ -7,3 +7,10 @@ Plugins can access:
 Plugins cannot:
 - Modify system files outside this project
 - Launch network connections unless explicitly whitelisted in `settings.json`
+
+## Future Granularity
+
+Additional permissions may restrict plugins to specific subfolders or
+allow read-only access. When implemented, each plugin will declare the
+exact paths and capabilities it requires. The dispatcher will enforce
+those limits to keep plugins sandboxed.


### PR DESCRIPTION
## Summary
- add log rotation via `RotatingFileHandler`
- show descriptions in `help` command by parsing `documentation.md`
- guard file-based commands with asyncio locks
- document upcoming permission granularity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849499990e0832fba270253307389d4