### PR TITLE
Add async Textual-based TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Audio playback is handled via the `simpleaudio` package for maximum cross-platfo
 ### Voice Input (optional)
 Lex listens using `speech_recognition`. When the Whisper package is installed, it falls back to Whisper for better accuracy. If `use_cloud` is `false`, all recognition happens locally; otherwise you may configure a cloud recognizer in the future.
 
+### Textual UI (optional)
+Run the interactive TUI with:
+
+```bash
+python textual_ui.py
+```
+
+Add `--sidebar` to display available command triggers in a side panel.
+
 ## ✅ What Works Now
 
 ### Functional Core

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -104,3 +104,8 @@ class Dispatcher:
                     return "[Lex] Something went wrong."
 
         return "[Lex] I don't know what you want, and I'm too tired to guess."
+
+    async def run_command(self, command: str) -> str:
+        """Public helper to execute a command string."""
+        self.check_for_updates()
+        return await self.dispatch(command)

--- a/documentation.md
+++ b/documentation.md
@@ -43,3 +43,8 @@ implementation.
 | hud.py | `hud` | Show a small CPU and memory usage overlay window. |
 | workflow.py | `workflow` | Create and execute multi-step command workflows. |
 
+## Textual UI
+
+Launch `textual_ui.py` for a simple text-based interface. Use the optional
+`--sidebar` flag to list available command triggers in a side panel.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyperclip
 psutil
 keyboard
 # simpleaudio
+textual

--- a/textual_ui.py
+++ b/textual_ui.py
@@ -1,0 +1,83 @@
+"""Minimal Textual-based TUI for Lex."""
+
+import asyncio
+import argparse
+
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.reactive import reactive
+from textual.widgets import Input, Log, Static
+
+from core.settings import load_settings
+from core.security import require_vault_key
+from dispatcher import Dispatcher
+
+
+class LexApp(App):
+    """Textual TUI that interacts with Lex's dispatcher."""
+
+    CSS = """
+    Screen { layout: vertical; }
+    #log { height: 1fr; }
+    #input { height:3; }
+    #sidebar { width:25; border:heavy $secondary; }
+    """
+
+    BINDINGS = [("enter", "submit", "Run command")]
+
+    show_sidebar = reactive(False)
+
+    def __init__(self, dispatcher: Dispatcher, *, sidebar: bool = False) -> None:
+        super().__init__()
+        self.dispatcher = dispatcher
+        self.show_sidebar = sidebar
+
+    def compose(self) -> ComposeResult:
+        if self.show_sidebar:
+            with Container(id="sidebar"):
+                yield Static(self._sidebar_text(), id="triggers")
+        yield Log(id="log")
+        yield Input(placeholder="Enter command", id="input")
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+
+    def _sidebar_text(self) -> str:
+        trigs = sorted(self.dispatcher.trigger_map.keys())
+        return "\n".join(trigs)
+
+    async def action_submit(self) -> None:
+        field = self.query_one(Input)
+        text = field.value.strip()
+        if not text:
+            return
+        log = self.query_one(Log)
+        log.write_line(f"> {text}")
+        field.value = ""
+        response = await self.dispatcher.run_command(text)
+        if response:
+            log.write_line(response)
+        if self.show_sidebar:
+            # reload sidebar in case commands changed
+            self.query_one("#triggers", Static).update(self._sidebar_text())
+
+
+async def main(sidebar: bool = False) -> None:
+    """Entry point to start the TUI."""
+
+    settings = load_settings()
+    key = require_vault_key()
+    dispatcher = Dispatcher({"settings": settings, "vault_key": key})
+    app = LexApp(dispatcher, sidebar=sidebar)
+    await app.run_async()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Lex Textual UI")
+    parser.add_argument(
+        "--sidebar",
+        action="store_true",
+        help="Show available command triggers",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(sidebar=args.sidebar))


### PR DESCRIPTION
## Summary
- add `LexApp` Textual interface in `textual_ui.py`
- expose a `run_command` helper in `Dispatcher`
- include Textual in dependencies
- document the TUI usage and CLI flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68494e408ee0832faa791d03b234b1c7