### PR TITLE
Add environment-based secrets and doctor command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for Lex
+# Copy to .env and set your secrets
+ELEVENLABS_API_KEY=
+ELEVENLABS_VOICE_ID=

--- a/README.md
+++ b/README.md
@@ -20,13 +20,18 @@ Lex targets **Python 3.11+**. Once you have the correct version installed:
 
 ### ElevenLabs TTS (optional)
 Lex can speak using the local `pyttsx3` engine or stream audio from ElevenLabs.
-To enable cloud-based text-to-speech, set `use_cloud` to `true` and configure your credentials in `settings.json`:
+To enable cloud-based text-to-speech, set `use_cloud` to `true` and store your credentials in environment variables (see `.env.example`):
 
 ```json
 "use_cloud": true,
-"tts_engine": "elevenlabs",
-"elevenlabs_api_key": "YOUR_KEY",
-"elevenlabs_voice_id": "VOICE_ID"
+"tts_engine": "elevenlabs"
+```
+
+Environment variables:
+
+```bash
+ELEVENLABS_API_KEY=YOUR_KEY
+ELEVENLABS_VOICE_ID=VOICE_ID
 ```
 
 Lex will then stream and play back voice responses from ElevenLabs.

--- a/commands/doctor.py
+++ b/commands/doctor.py
@@ -1,0 +1,48 @@
+import asyncio
+import importlib.util
+import os
+import sys
+
+REQUIRED_PACKAGES = ["requests", "pyttsx3", "psutil"]
+
+
+class Command:
+    """Run basic diagnostic checks for the Lex environment."""
+
+    trigger = ["doctor"]
+
+    def __init__(self, context):
+        self.context = context
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+
+        issues = []
+
+        if sys.version_info < (3, 11):
+            issues.append("Python 3.11+ required")
+
+        for pkg in REQUIRED_PACKAGES:
+            if importlib.util.find_spec(pkg) is None:
+                issues.append(f"Missing package: {pkg}")
+
+        settings = self.context.get("settings", {})
+        if (
+            settings.get("use_cloud")
+            and settings.get("tts_engine") == "elevenlabs"
+        ):
+            if not settings.get("elevenlabs_api_key") or not settings.get(
+                "elevenlabs_voice_id"
+            ):
+                issues.append("ElevenLabs credentials not configured")
+
+        data_dir = os.path.join(os.getcwd(), "memory")
+        if not os.path.isdir(data_dir):
+            issues.append("memory/ directory missing")
+
+        if issues:
+            joined = "\n".join(f"- {i}" for i in issues)
+            return "[Lex] Doctor found issues:\n" + joined
+
+        return "[Lex] System looks good."
+

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,6 +1,7 @@
 import json
 import os
 from .logger import get_logger
+from dotenv import load_dotenv
 
 DEFAULTS = {
     "sarcasm_level": 5,
@@ -22,7 +23,11 @@ logger = get_logger()
 
 def load_settings(path: str = "settings.json") -> dict:
     """Load settings from a JSON file, merging with defaults."""
+    # Load environment variables from a local .env file if present
+    load_dotenv(override=False)
+
     data = DEFAULTS.copy()
+
     if os.path.exists(path):
         try:
             with open(path, "r", encoding="utf-8") as fh:
@@ -31,4 +36,14 @@ def load_settings(path: str = "settings.json") -> dict:
                 data.update(file_data)
         except Exception as e:
             logger.error("ERROR loading settings: %s", e)
+
+    # Override sensitive values from environment variables when available
+    env_map = {
+        "elevenlabs_api_key": os.getenv("ELEVENLABS_API_KEY"),
+        "elevenlabs_voice_id": os.getenv("ELEVENLABS_VOICE_ID"),
+    }
+    for key, value in env_map.items():
+        if value:
+            data[key] = value
+
     return data

--- a/documentation.md
+++ b/documentation.md
@@ -18,6 +18,7 @@ implementation.
 | help.py | `help` | List all available command triggers. |
 | history.py | `history`, `context` | Show recent command history and results. |
 | info.py | `info` | Display loaded commands and current settings. |
+| doctor.py | `doctor` | Run diagnostics to check your Lex setup. |
 | knowledge.py | `knowledge` | Search local documentation for matching lines. |
 | learn.py | `learn`, `teach` | Teach Lex new phrases that map to commands. |
 | notes.py | `notes`, `note` | Store short notes locally. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ psutil
 keyboard
 # simpleaudio
 textual
+python-dotenv

--- a/tests/test_commands/test_doctor.py
+++ b/tests/test_commands/test_doctor.py
@@ -1,0 +1,9 @@
+import pytest
+from commands.doctor import Command
+
+
+@pytest.mark.asyncio
+async def test_doctor_runs():
+    cmd = Command({"settings": {}})
+    result = await cmd.run("")
+    assert result.startswith("[Lex]")

--- a/todo.md
+++ b/todo.md
@@ -36,7 +36,7 @@
 - [ ] Add unit tests for dispatcher routing
 - [ ] Write basic test scaffolds for all plugins
 - [ ] Mock voice input / TTS output for CI testing
-- [ ] Add `lex doctor` diagnostic command  
+- [x] Add `lex doctor` diagnostic command
       → Check for missing deps, bad config, incompatible Python, etc.
 
 ---
@@ -65,7 +65,7 @@
 
 ## 🧾 Housekeeping / Dev Quality
 
-- [ ] Add `.env.example` + load secrets from env properly  
+- [x] Add `.env.example` + load secrets from env properly
       → Avoid leaking ElevenLabs keys in `settings.json`
 
 - [ ] Document each plugin:


### PR DESCRIPTION
## Summary
- load `.env` values in settings
- add `lex doctor` diagnostic command
- document new command and env workflow
- include `.env.example` template
- add tests for the new command

## Testing
- `pip install python-dotenv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849576e62c4832f8d3543083ead39d6