### PR TITLE
Improve context model and add command suggestions

### DIFF
--- a/commands/personality.py
+++ b/commands/personality.py
@@ -10,6 +10,8 @@ class Command:
     async def run(self, args: str) -> str:
         """Get or set sarcasm level."""
         settings = self.context.get("settings", {})
+        from personality import responder
+        responder.reload_responses()
         arg = args.strip()
         await asyncio.sleep(0)
 

--- a/commands/secdash.py
+++ b/commands/secdash.py
@@ -24,6 +24,9 @@ class Command:
         await asyncio.sleep(0)
         tokens = args.split()
         if tokens and tokens[0] == "kill" and len(tokens) > 1:
+            settings = self.context.get("settings", {})
+            if not settings.get("allow_process_terminate", False):
+                return "[Lex] Process termination disabled in settings."
             try:
                 pid = int(tokens[1])
                 psutil.Process(pid).terminate()

--- a/core/context.py
+++ b/core/context.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any, Iterator
+
+
+class LexContext(MutableMapping):
+    """Context container separating system, user and plugin data."""
+
+    def __init__(self, data: dict | None = None) -> None:
+        data = data or {}
+        self.system: dict = data.get("system", {})
+        self.user: dict = data.get("user", {})
+        self.plugin: dict = data.get("plugin", {})
+        self.system.update(
+            {k: v for k, v in data.items() if k not in {"system", "user", "plugin"}}
+        )
+
+    # Mapping protocol -------------------------------------------------
+    def __getitem__(self, key: str) -> Any:
+        if key in {"system", "user", "plugin"}:
+            return getattr(self, key)
+        for space in (self.system, self.user, self.plugin):
+            if key in space:
+                return space[key]
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if key in {"system", "user", "plugin"}:
+            setattr(self, key, value)
+        else:
+            self.system[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        for space in (self.system, self.user, self.plugin):
+            if key in space:
+                del space[key]
+                return
+        raise KeyError(key)
+
+    def __iter__(self) -> Iterator[str]:
+        yield from {"system", "user", "plugin"}
+        for space in (self.system, self.user, self.plugin):
+            yield from space.keys()
+
+    def __len__(self) -> int:
+        return sum(len(s) for s in (self.system, self.user, self.plugin)) + 3
+
+    # Convenience helpers ---------------------------------------------
+    def get(self, key: str, default: Any = None) -> Any:  # type: ignore[override]
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def setdefault(self, key: str, default: Any) -> Any:  # type: ignore[override]
+        if key in self:
+            return self[key]
+        self[key] = default
+        return default
+

--- a/core/settings.py
+++ b/core/settings.py
@@ -15,6 +15,8 @@ DEFAULTS = {
     "elevenlabs_api_key": "",
     "elevenlabs_voice_id": "",
     "fuzzy_threshold": 0.75,
+    "plugin_timeout": 5.0,
+    "allow_process_terminate": False,
 }
 
 

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -4,6 +4,9 @@ import os
 import pkgutil
 import sys
 from typing import List
+import difflib
+
+from core.context import LexContext
 
 import asyncio
 
@@ -15,9 +18,12 @@ logger = get_logger()
 class Dispatcher:
     def __init__(self, context: dict | None = None, package: str = "commands"):
         self.package = package
-        self.context = context or {}
+        self.context = LexContext(context)
+        # maintain legacy top-level keys
         self.context["dispatcher"] = self
         self.context.setdefault("history", [])
+        settings = self.context.get("settings", {})
+        self.timeout = float(settings.get("plugin_timeout", 5.0) or 5.0)
         self.commands: List[object] = []
         self.trigger_map: dict[str, object] = {}
         self.module_mtimes: dict[str, float] = {}
@@ -51,6 +57,17 @@ class Dispatcher:
         while True:
             await asyncio.sleep(interval)
             self.check_for_updates()
+
+    async def _safe_execute(self, cmd: object, args: str) -> str:
+        """Execute a command with sandboxing and exception handling."""
+        try:
+            return await asyncio.wait_for(cmd.run(args), timeout=self.timeout)
+        except asyncio.TimeoutError:
+            logger.warning("%s timed out", cmd.__class__.__name__)
+            return "[Lex] Command timed out."
+        except Exception:
+            logger.exception("Error in %s", cmd.__class__.__name__)
+            return "[Lex] Something went wrong."
 
     def load_modules(self) -> None:
         self.commands.clear()
@@ -93,19 +110,20 @@ class Dispatcher:
         for trig, cmd in self.trigger_map.items():
             if lowered.startswith(trig):
                 args = text[len(trig):].strip()
-                try:
-                    result = await cmd.run(args)
-                    self.context["last_command"] = trig
-                    self.context["last_result"] = result
-                    history = self.context.get("history")
-                    if isinstance(history, list):
-                        history.append((input_text, result))
-                        if len(history) > 20:
-                            del history[:-20]
-                    return result
-                except Exception as e:
-                    logger.exception("Error in %s", cmd.__class__.__name__)
-                    return "[Lex] Something went wrong."
+                result = await self._safe_execute(cmd, args)
+                self.context["last_command"] = trig
+                self.context["last_result"] = result
+                history = self.context.get("history")
+                if isinstance(history, list):
+                    history.append((input_text, result))
+                    if len(history) > 20:
+                        del history[:-20]
+                return result
+
+        first = text.split()[0].lower() if text else ""
+        matches = difflib.get_close_matches(first, self.trigger_map.keys(), n=1, cutoff=0.6)
+        if matches:
+            return f"[Lex] Unknown command. Did you mean: {matches[0]}?"
 
         return "[Lex] I don't know what you want, and I'm too tired to guess."
 

--- a/personality/responder.py
+++ b/personality/responder.py
@@ -1,21 +1,45 @@
+import glob
 import json
 import os
 import random
-from functools import lru_cache
 
-RESPONSES_FILE = os.path.join("personality", "responses.json")
+RESPONSES_DIR = os.path.join("personality")
+_CACHE: dict | None = None
+_MTIME: float = 0.0
 
 
-@lru_cache(maxsize=1)
-def load_responses() -> dict:
-    """Load canned responses from disk with simple caching."""
-    if not os.path.exists(RESPONSES_FILE):
-        return {}
-    try:
-        with open(RESPONSES_FILE, "r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except Exception:
-        return {}
+def _current_mtime() -> float:
+    times = []
+    for path in glob.glob(os.path.join(RESPONSES_DIR, "*.json")):
+        try:
+            times.append(os.path.getmtime(path))
+        except OSError:
+            continue
+    return max(times) if times else 0.0
+
+
+def load_responses(force_reload: bool = False) -> dict:
+    """Load and merge all personality JSON files."""
+    global _CACHE, _MTIME
+    mtime = _current_mtime()
+    if force_reload or _CACHE is None or mtime != _MTIME:
+        data: dict = {}
+        for path in glob.glob(os.path.join(RESPONSES_DIR, "*.json")):
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    part = json.load(fh)
+                if isinstance(part, dict):
+                    data.update(part)
+            except Exception:
+                continue
+        _CACHE = data
+        _MTIME = mtime
+    return _CACHE or {}
+
+
+def reload_responses() -> None:
+    """Force reload personality data from disk."""
+    load_responses(force_reload=True)
 
 
 def get_sarcasm(settings: dict) -> str:

--- a/settings.json
+++ b/settings.json
@@ -8,5 +8,7 @@
   "voice_rate": 150,
   "voice_pitch": 50,
   "elevenlabs_api_key": "",
-  "elevenlabs_voice_id": ""
+  "elevenlabs_voice_id": "",
+  "plugin_timeout": 5.0,
+  "allow_process_terminate": false
 }

--- a/tests/test_commands/test_personality_dynamic.py
+++ b/tests/test_commands/test_personality_dynamic.py
@@ -1,0 +1,12 @@
+import json
+import pytest
+from personality import responder
+
+
+def test_dynamic_loading(tmp_path, monkeypatch):
+    file = tmp_path / "extra.json"
+    file.write_text(json.dumps({"ping": ["dynamic"]}))
+    monkeypatch.setattr(responder, "RESPONSES_DIR", tmp_path)
+    responder.reload_responses()
+    data = responder.load_responses()
+    assert "dynamic" in data.get("ping", [])

--- a/tests/test_commands/test_secdash.py
+++ b/tests/test_commands/test_secdash.py
@@ -1,0 +1,9 @@
+import pytest
+from commands.secdash import Command
+
+
+@pytest.mark.asyncio
+async def test_kill_disabled():
+    cmd = Command({"settings": {"allow_process_terminate": False}})
+    result = await cmd.run("kill 123")
+    assert "disabled" in result.lower()

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 
 from core.settings import load_settings
 from dispatcher import Dispatcher
@@ -79,3 +80,39 @@ async def test_nlp_fuzzy_match(tmp_path):
     # Intentionally misspelled command
     resp = await dispatcher.dispatch("remmind me to sleep")
     assert "Reminder saved" in resp
+
+
+@pytest.mark.asyncio
+async def test_command_timeout(monkeypatch):
+    settings = load_settings()
+    settings["plugin_timeout"] = 0.1
+    dispatcher = Dispatcher({"settings": settings})
+
+    class Dummy:
+        trigger = ["hang"]
+
+        async def run(self, _args):
+            await asyncio.sleep(1)
+            return "done"
+
+    dummy = Dummy()
+    dispatcher.commands.append(dummy)
+    dispatcher.trigger_map["hang"] = dummy
+
+    result = await dispatcher.dispatch("hang")
+    assert "timed out" in result.lower()
+
+@pytest.mark.asyncio
+async def test_auto_suggest():
+    settings = load_settings()
+    settings["fuzzy_threshold"] = 1.0
+    dispatcher = Dispatcher({"settings": settings})
+    result = await dispatcher.dispatch("pimg")
+    assert "did you mean" in result.lower()
+
+
+def test_context_nested():
+    dispatcher = Dispatcher({"settings": load_settings()})
+    ctx = dispatcher.context
+    assert "system" in ctx
+    assert ctx["settings"] is ctx.system.get("settings")

--- a/todo.md
+++ b/todo.md
@@ -4,16 +4,16 @@
 
 ## 🔥 Critical (Breaks UX or Causes Crashes)
 
-- [ ] Add exception handling to all `Command.run()` calls  
+- [x] Add exception handling to all `Command.run()` calls
       → Prevent whole-system crash when a plugin explodes
 
-- [ ] Implement plugin sandboxing  
+- [x] Implement plugin sandboxing
       → Timeout or fallback if a plugin stalls or fails
 
-- [ ] Harden dangerous commands (e.g. `kill`)  
+- [x] Harden dangerous commands (e.g. `kill`)
       → Add opt-in flags or explicit confirmations via settings
 
-- [ ] Improve `context` structure  
+- [x] Improve `context` structure
       → Avoid dumping everything into one dict — separate into `system`, `user`, `plugin`
 
 ---
@@ -33,7 +33,7 @@
 
 ## 🧪 Testing & Stability
 
-- [ ] Add unit tests for dispatcher routing
+- [x] Add unit tests for dispatcher routing
 - [ ] Write basic test scaffolds for all plugins
 - [ ] Mock voice input / TTS output for CI testing
 - [x] Add `lex doctor` diagnostic command
@@ -43,13 +43,13 @@
 
 ## 🔊 UX & Quality-of-Life
 
-- [ ] Command auto-suggest on unknown triggers  
+- [x] Command auto-suggest on unknown triggers
       → “Did you mean: remind?”
 
 - [ ] Local command usage logging + frequency analytics  
       → View most-used plugins and drop unused ones
 
-- [ ] Add dynamic personality loading  
+- [x] Add dynamic personality loading
       → Load `/personality/*.json` at runtime (switch tone mid-session)
 
 ---


### PR DESCRIPTION
## Summary
- create `LexContext` for organizing system, user, and plugin data
- update dispatcher to use `LexContext`
- provide auto-suggestions when a command isn't recognized
- add tests for suggestions and context structure
- mark relevant TODO items complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684958b58ab0832f9ecbccaf7a6da0cc