### PR TITLE
Add theme system to Textual UI

### DIFF
--- a/commands/theme.py
+++ b/commands/theme.py
@@ -1,0 +1,44 @@
+"""Switch Lex's Textual UI theme.
+
+Available themes live in the ``themes/`` folder and ship with ``lex`` and ``meme`` styles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import List
+
+from core.settings import save_settings
+
+THEMES_DIR = Path("themes")
+SETTINGS_FILE = Path("settings.json")
+
+
+class Command:
+    """Change the active UI theme."""
+
+    trigger = ["theme"]
+    description = "Change the Textual UI theme. Usage: theme <name>"
+
+    def __init__(self, context):
+        self.context = context
+
+    def _available(self) -> List[str]:
+        return [p.stem for p in THEMES_DIR.glob("*.css")]
+
+    async def run(self, args: str) -> str:
+        await asyncio.sleep(0)
+        name = args.strip()
+        if not name:
+            return f"[Lex] Usage: theme <name>. Available: {', '.join(self._available())}"
+        if name not in self._available():
+            return f"[Lex] Unknown theme. Available: {', '.join(self._available())}"
+        settings = self.context.get("settings", {})
+        settings["theme"] = name
+        save_settings(settings, str(SETTINGS_FILE))
+        app = self.context.get("app")
+        if app and hasattr(app, "set_theme"):
+            if app.set_theme(name):
+                return f"[Lex] Theme switched to {name}."
+        return "[Lex] Theme saved. Restart Lex to apply."

--- a/core/settings.py
+++ b/core/settings.py
@@ -17,6 +17,7 @@ DEFAULTS = {
     "fuzzy_threshold": 0.75,
     "plugin_timeout": 5.0,
     "allow_process_terminate": False,
+    "theme": "lex",
 }
 
 
@@ -49,3 +50,12 @@ def load_settings(path: str = "settings.json") -> dict:
             data[key] = value
 
     return data
+
+
+def save_settings(data: dict, path: str = "settings.json") -> None:
+    """Write settings to disk."""
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+    except Exception as e:
+        logger.error("ERROR saving settings: %s", e)

--- a/documentation.md
+++ b/documentation.md
@@ -35,6 +35,7 @@ implementation.
 | smarthome.py | `smarthome` | Control lights, thermostat, or scenes via Home Assistant. |
 | system.py | `system` | Show basic system information. |
 | tone.py | `tone` | Adjust voice name, rate and pitch. |
+| theme.py | `theme` | Change the Textual UI theme. |
 | tools.py | `tools` | Generate UUIDs or random passwords. |
 | translate.py | `translate` | Translate text using a small offline dictionary or cloud API. |
 | usage.py | `usage` | Show command usage statistics. |

--- a/tests/test_commands/test_theme.py
+++ b/tests/test_commands/test_theme.py
@@ -1,0 +1,22 @@
+import json
+import pytest
+
+from commands import theme
+
+
+@pytest.mark.asyncio
+async def test_theme_updates_settings(tmp_path, monkeypatch):
+    themes = tmp_path / "themes"
+    themes.mkdir()
+    (themes / "lex.css").write_text("")
+    (themes / "meme.css").write_text("")
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(theme, "THEMES_DIR", themes)
+    monkeypatch.setattr(theme, "SETTINGS_FILE", settings_file)
+
+    settings = {}
+    cmd = theme.Command({"settings": settings})
+    resp = await cmd.run("meme")
+    assert "meme" in resp or settings.get("theme") == "meme"
+    data = json.load(open(settings_file))
+    assert data["theme"] == "meme"

--- a/textual_ui.py
+++ b/textual_ui.py
@@ -1,0 +1,146 @@
+"""Textual-based frontend for Lex with theme support."""
+
+import asyncio
+import argparse
+import logging
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.reactive import reactive
+from textual.widgets import Input, Log, Static, Header, Footer
+
+from core.settings import load_settings
+from core.security import require_vault_key
+from dispatcher import Dispatcher
+from core.logger import set_log_level
+
+LEX_VERSION = "0.1.0"
+THEMES_DIR = Path("themes")
+
+
+class LexApp(App):
+    """Textual TUI that interacts with Lex's dispatcher."""
+
+    BINDINGS = [("enter", "submit", "Run command")]
+    show_sidebar = reactive(False)
+
+    def __init__(self, dispatcher: Dispatcher, *, sidebar: bool = False, theme: str = "lex") -> None:
+        theme_path = THEMES_DIR / f"{theme}.css"
+        super().__init__(css_path=str(theme_path))
+        self.dispatcher = dispatcher
+        self.show_sidebar = sidebar
+        self.history: list[str] = []
+        self.history_index: int = 0
+
+    # -----------------------------------------------------
+    # Theme handling
+    # -----------------------------------------------------
+    def set_theme(self, name: str) -> bool:
+        """Attempt to reload the UI with the given theme."""
+        path = THEMES_DIR / f"{name}.css"
+        if not path.exists():
+            return False
+        self.css_path = [path]
+        self.stylesheet.read_all(self.css_path)
+        self.stylesheet.parse()
+        self.refresh_css()
+        return True
+
+    # -----------------------------------------------------
+    # Layout
+    # -----------------------------------------------------
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        if self.show_sidebar:
+            with Container(id="sidebar"):
+                yield Static(self._sidebar_text(), id="triggers")
+        yield Log(id="log")
+        yield Input(placeholder="Enter command", id="input")
+        yield Footer()
+        yield Static(f"Lex v{LEX_VERSION} by Dyhrrr", id="version")
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+        settings = self.dispatcher.context.get("settings", {})
+        cloud = "ON" if settings.get("use_cloud") else "OFF"
+        sarcasm = settings.get("sarcasm_level", 0)
+        plugins = len(self.dispatcher.commands)
+        self.sub_title = f"Cloud: {cloud} | Sarcasm: {sarcasm} | Plugins: {plugins}"
+
+    def _sidebar_text(self) -> str:
+        trigs = sorted(self.dispatcher.trigger_map.keys())
+        return "\n".join(trigs)
+
+    async def action_submit(self) -> None:
+        field = self.query_one(Input)
+        text = field.value.strip()
+        if not text:
+            return
+        log = self.query_one(Log)
+        log.write_line(f"> {text}")
+        log.scroll_end(animate=False)
+        field.value = ""
+        self.history.append(text)
+        self.history_index = len(self.history)
+        try:
+            response = await self.dispatcher.run_command(text)
+        except Exception as e:
+            response = f"[ERROR] {e}"
+        if response:
+            log.write_line(response)
+            log.scroll_end(animate=False)
+        if self.show_sidebar:
+            # reload sidebar in case commands changed
+            self.query_one("#triggers", Static).update(self._sidebar_text())
+
+    def on_key(self, event) -> None:
+        input_widget = self.query_one(Input)
+        if not input_widget.has_focus:
+            return
+        if event.key == "up":
+            if self.history:
+                self.history_index = max(0, self.history_index - 1)
+                input_widget.value = self.history[self.history_index]
+                input_widget.cursor_position = len(input_widget.value)
+                event.prevent_default()
+        elif event.key == "down":
+            if self.history:
+                self.history_index = min(len(self.history), self.history_index + 1)
+                if self.history_index < len(self.history):
+                    input_widget.value = self.history[self.history_index]
+                else:
+                    input_widget.value = ""
+                input_widget.cursor_position = len(input_widget.value)
+                event.prevent_default()
+
+
+async def main(sidebar: bool = False) -> None:
+    """Entry point to start the TUI."""
+
+    settings = load_settings()
+    key = require_vault_key()
+    dispatcher = Dispatcher({"settings": settings, "vault_key": key})
+    theme = settings.get("theme", "lex")
+    app = LexApp(dispatcher, sidebar=sidebar, theme=theme)
+    dispatcher.context["app"] = app
+    await app.run_async()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Lex Textual UI")
+    parser.add_argument(
+        "--sidebar",
+        action="store_true",
+        help="Show available command triggers",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    parser.add_argument("--quiet", action="store_true", help="Only show warnings")
+    args = parser.parse_args()
+
+    if args.verbose:
+        set_log_level(logging.DEBUG)
+    elif args.quiet:
+        set_log_level(logging.WARNING)
+
+    asyncio.run(main(sidebar=args.sidebar))

--- a/themes/lex.css
+++ b/themes/lex.css
@@ -1,0 +1,15 @@
+/* Default Lex dark theme */
+Screen {
+    background: #101010;
+    color: #e0e0e0;
+}
+#sidebar {
+    border: heavy #36d6c5;
+}
+Header, Footer {
+    background: #181818;
+    color: #36d6c5;
+}
+#version {
+    color: #ff66ff;
+}

--- a/themes/meme.css
+++ b/themes/meme.css
@@ -1,0 +1,15 @@
+/* Meme insanity theme */
+Screen {
+    background: yellow;
+    color: red;
+}
+#sidebar {
+    border: heavy magenta;
+}
+Header, Footer {
+    background: lime;
+    color: blue;
+}
+#version {
+    color: hotpink;
+}


### PR DESCRIPTION
## Summary
- implement theme choice in `textual_ui.py`
- add theme files and plugin to switch between them
- expose `save_settings` helper and default theme in settings
- document theme command
- test theme plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849736681ac832f91fca630fe03aa17